### PR TITLE
Ignore hidden tabs

### DIFF
--- a/src/background/commands.js
+++ b/src/background/commands.js
@@ -546,7 +546,7 @@ modules.commands = (function (settings, helpers) {
 
   // Get the tabs in the current window.
   function getCurrentWindowTabs () {
-    return browser.tabs.query({ currentWindow: true }).filter(tab => !tab.hidden);
+    return browser.tabs.query({ currentWindow: true }).then(tabs => tabs.filter(tab => !tab.hidden));
   }
 
   // Receive a callback with the active tab.

--- a/src/background/commands.js
+++ b/src/background/commands.js
@@ -546,7 +546,7 @@ modules.commands = (function (settings, helpers) {
 
   // Get the tabs in the current window.
   function getCurrentWindowTabs () {
-    return browser.tabs.query({ currentWindow: true });
+    return browser.tabs.query({ currentWindow: true }).filter(tab => !tab.hidden);
   }
 
   // Receive a callback with the active tab.


### PR DESCRIPTION
Needed to make tab navigation work well. I haven't checked if `getCurrentWindowTabs` is used in places where it should return hidden tabs, but treating hidden tabs as being on a different window should be fine.