### PR TITLE
Fixes download prompt on macOS and Linux (#147)

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,6 +27,7 @@
   "permissions": [
     "browserSettings",
     "cookies",
+    "downloads",
     "sessions",
     "storage",
     "tabs"

--- a/src/options/options.tab.backup.js
+++ b/src/options/options.tab.backup.js
@@ -19,17 +19,14 @@ app.controller('OptionsTabBackupCtrl', [
     // Present a download to save the settings backup to a file.
     $scope.downloadSettings = () => {
       return $scope.getSettingsBackup().then(backupData => {
-        // Stringify and serialize the backup data.
-        let jsonData = JSON.stringify(backupData, null, 2);
-        let dataUrl = 'data:application/json;charset=utf-8,' + encodeURIComponent(jsonData);
-
         // Prompt the user to download the backup.
-        let a = window.document.createElement('a');
-        a.href = dataUrl;
-        a.download = backupData.fileName;
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
+        let jsonData = JSON.stringify(backupData, null, 2);
+        let blob = new Blob([jsonData], {type: 'application/json'});
+        let dataUrl = window.URL.createObjectURL(blob);
+        browser.downloads.download({
+                url : dataUrl,
+                filename : backupData.fileName
+        });
       });
     };
 


### PR DESCRIPTION
resolves #147 

From what I could gather, downloading files client side seems to work a little bit differently in WebExtensions than in a standard web page. In the previous implementation, changing the MIME type to `application/octet-stream` would give a download prompt as expected, but with a type `application/json`, the browser just opens it instead for some reason.

So I implemented the download using the [WebExtension downloads API](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/downloads). The only caveat is that this required adding the downloads permission to the `manifest.json`.

This works for me on Linux, but I don't have a mac to test it on.